### PR TITLE
Add ES6 back quote support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,11 +4,12 @@ export const SELECT_QUOTES_COMMAND_ID = "select-quotes";
 
 export const DOUBLE_QUOTE = "\"";
 export const SINGLE_QUOTE = "'";
+export const BACK_QUOTE = "`";
 
 export const DEFAULT_POSITION:  Position  = new Position(0,0);
 export const DEFAULT_SELECTION: Selection = new Selection(DEFAULT_POSITION, DEFAULT_POSITION);
 
-export const isQuote = (c: string) => c === DOUBLE_QUOTE || c === SINGLE_QUOTE;
+export const isQuote = (c: string) => c === DOUBLE_QUOTE || c === SINGLE_QUOTE || c === BACK_QUOTE;
 
 export const isMouseEvent             = (e: TextEditorSelectionChangeEvent) => e.kind === TextEditorSelectionChangeKind.Mouse;
 export const isOnlyOneActiveSelection = (e: TextEditorSelectionChangeEvent) => e.selections.length === 1;


### PR DESCRIPTION
Added back quote selection support for Javascript ES6 template strings
As far as I can tell, this works and doesn't break things